### PR TITLE
fix windows deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,3 @@ with it:
 need support for another programming language or protocol or simply cannot
 figure out how to make it work, do not hesitate to open an
 [issue](https://github.com/go-crzy/crzy/issues).
-
-## known issues
-
-`crzy` does not support Windows

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/gregoryguillou/go-git-http-xfer v1.4.1-0.20210501161012-03cf1dc949d9
 	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -207,15 +207,15 @@ func (g *GitServer) Update(repo string) {
 			log.Info("executable is already running", "data", exe)
 			return
 		}
-		port, err := g.upstream.NextPort()
+		addr, err := g.upstream.NextAddr()
 		if err != nil {
-			log.Error(err, "no port available")
+			log.Error(err, "no address available")
 			return
 		}
 		cmd := exec.Command(artifact)
-		cmd.Env = []string{fmt.Sprintf("PORT=%s", port)}
-		log.Info("starting instance", "data", fmt.Sprintf("%s,%s", exe, port))
-		g.upstream.Register(exe, "v1", HTTPProcess{Addr: port, Cmd: cmd}, true)
+		cmd.Env = []string{fmt.Sprintf("ADDR=%s", addr)}
+		log.Info("starting instance", "data", fmt.Sprintf("%s,%s", exe, addr))
+		g.upstream.Register(exe, "v1", HTTPProcess{Addr: addr, Cmd: cmd}, true)
 		cmd.Start()
 		if old == "" {
 			return

--- a/pkg/logr.go
+++ b/pkg/logr.go
@@ -88,16 +88,22 @@ func (c *crzyLogger) Log(key string, msg string, keysAndValues ...interface{}) {
 		msg,
 	)
 	i := 0
-	payload := c.keysAndValues
+	keys := map[string]string{}
+	if msg, ok := c.keysAndValues["msg"]; ok {
+		keys["msg"] = msg
+	}
+	if data, ok := c.keysAndValues["data"]; ok {
+		keys["data"] = data
+	}
 	for i < len(keysAndValues)-1 {
 		key := fmt.Sprintf("%v", keysAndValues[i])
 		val := fmt.Sprintf("%v", keysAndValues[i+1])
 		i += 2
 		if key == "msg" || key == "data" {
-			payload[key] = val
+			keys[key] = val
 		}
 	}
-	if msg, ok := payload["msg"]; ok {
+	if msg, ok := keys["msg"]; ok {
 		log += fmt.Sprintf(", msg:%-50s", msg)
 		if len(msg) > 50 {
 			log += "... "
@@ -105,7 +111,7 @@ func (c *crzyLogger) Log(key string, msg string, keysAndValues ...interface{}) {
 			log += "    "
 		}
 	}
-	if data, ok := payload["data"]; ok {
+	if data, ok := keys["data"]; ok {
 		n := 50
 		if len(data) < n {
 			n = len(data)
@@ -129,6 +135,14 @@ func colorPrint(name, log string) {
 			fgColor = color.FgRed
 		case "main":
 			fgColor = color.FgGreen
+		case "git":
+			fgColor = color.FgHiYellow
+		case "updater":
+			fgColor = color.FgHiBlue
+		case "signal":
+			fgColor = color.FgHiRed
+		case "cron":
+			fgColor = color.FgHiGreen
 		default:
 			fgColor = color.FgMagenta
 		}

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	conf       = &config{}
+	conf = &config{}
 )
 
 type config struct {
@@ -72,24 +72,28 @@ func heading() {
 }
 
 func usage(version, commit, date, builtBy string) {
-	v := false
 	configFile := ""
-	repository := "myrepo"
-	head       := "master"
-	server     := false
-	colorize   := false
+	flag.StringVar(&configFile, "config", "crzy.yaml", "configuration file")
+	repository := ""
+	head := ""
+	server := false
+	colorize := false
 	flag.StringVar(&repository, "repository", "myrepo", "GIT repository target name")
 	flag.StringVar(&head, "head", "main", "GIT repository target name")
-	flag.StringVar(&configFile, "config", "crzy.yaml", "configuration file")
-	flag.BoolVar(&server, "server", false, "run as a server")
-	flag.BoolVar(&v, "version", false, "display the version")
 	flag.BoolVar(&colorize, "color", false, "colorize logs")
+	flag.BoolVar(&server, "server", false, "run as a server")
+	v := false
+	flag.BoolVar(&v, "version", false, "display the version")
 	flag.Parse()
+	if v {
+		fmt.Printf("crzy version %s\n", version)
+		os.Exit(0)
+	}
 	getConfig(configFile)
-	if repository != "myrepo" {
+	if repository != "myrepo" || conf.Main.Repository == "" {
 		conf.Main.Repository = repository
 	}
-	if head != "main" { 
+	if head != "main" || conf.Main.Head == "" {
 		conf.Main.Head = head
 	}
 	if colorize {
@@ -98,11 +102,7 @@ func usage(version, commit, date, builtBy string) {
 	if server {
 		conf.Main.Server = server
 	}
-	if v {
-		fmt.Printf("crzy version %s\n", version)
-		os.Exit(0)
-	}
-	if !server {
+	if !conf.Main.Server {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}


### PR DESCRIPTION
Improve the code to manage Windows:

- Remove the document
- Move PORT to ADDR in order to connect Windows to localhost, instead of 0.0.0.0
- Add colors in the logs
- Do not register variable in receiver when logging to prevent padding
- Manage default values in configuration file