### PR TITLE
manage nil errors in logs

### DIFF
--- a/pkg/logr.go
+++ b/pkg/logr.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,10 +45,16 @@ func (c *crzyLogger) Info(msg string, keysAndValues ...interface{}) {
 func (c *crzyLogger) Error(err error, msg string, keysAndValues ...interface{}) {
 	switch len(keysAndValues) {
 	case 0:
+		if err == nil {
+			err = errors.New("unknown")
+		}
 		c.Log("error", "err:"+err.Error(), "msg", msg)
 	default:
 		keysAndValues = append(keysAndValues, "msg")
 		keysAndValues = append(keysAndValues, msg)
+		if err == nil {
+			err = errors.New("unknown")
+		}
 		c.Log("error", "err:"+err.Error(), keysAndValues...)
 	}
 }

--- a/pkg/release.go
+++ b/pkg/release.go
@@ -63,7 +63,6 @@ OUTER:
 					getEnv(action.envs, "version"), "release",
 					runnerStatusDone,
 					step{execStruct: cmd, Name: w.flow})
-				log.Error(err, "execution error")
 				log.Info("release execution succeeded...")
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
This fixes a bug, i.e. the use of a `log.Error` when there is actually no error as well as the fact the log primitive does not check for that case and crashes.