### PR TITLE
fix issue with version/docker

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,10 +13,13 @@ builds:
   - amd64
   - arm64
   ldflags:
-  - -s -w -X pkg.build={{.Version}} -X pkg.commit={{.ShortCommit}}
+  - -s -w -X github.com/go-crzy/crzy/pkg.version={{.Version}} -X github.com/go-crzy/crzy/pkg.commit={{.ShortCommit}}
   ignore:
   - goos: windows
     goarch: arm64
+after:
+  hooks:
+  - echo {{.Version}} {{.ShortCommit}}
 archives:
 - replacements:
     386: i386
@@ -26,8 +29,6 @@ archives:
       format: zip
 checksum:
   name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
 brews:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV DOCKER_TAG $DOCKER_TAG
 WORKDIR /build
 COPY . .
 RUN go mod download && CGO_ENABLED=0 go build \
-  -ldflags "-s -w -X main.version=${DOCKER_TAG:-dev} -X main.commit=${SOURCE_COMMIT:-unknown}" \
+  -ldflags "-s -w -X github.com/go-crzy/crzy/pkg.version=${DOCKER_TAG:-dev} -X github.com/go-crzy/crzy/pkg.commit=${SOURCE_COMMIT:-unknown}" \
   -o crzy .
 
 FROM golang:1.16-alpine
@@ -20,4 +20,3 @@ ENV REPOSITORY myrepo
 EXPOSE 8080
 EXPOSE 8081
 ENTRYPOINT ["/bin/crzy"]
-CMD ["-server", "-repository", "${REPOSITORY}"]


### PR DESCRIPTION
This PR fixes the 2 following known issues:
- we've removed the `-server` flag from the CLI but it was remaining in the `Dockerfile`
- the version was not prefixed with the full package name as a result it was always displaying `dev` on `crzy -version`

This PR should fix the 2 issues