### PR TITLE
remove after section from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ before:
   hooks:
   - go mod tidy
   - go generate ./...
+  - echo {{.Version}} {{.ShortCommit}}
 builds:
 - env:
   - CGO_ENABLED=0
@@ -17,9 +18,6 @@ builds:
   ignore:
   - goos: windows
     goarch: arm64
-after:
-  hooks:
-  - echo {{.Version}} {{.ShortCommit}}
 archives:
 - replacements:
     386: i386


### PR DESCRIPTION
It looks like goreleaser does not have a `after` section despite the documentation. The release has failed.