### PR TITLE
Add custom build to docker hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 FROM golang:1.16-alpine as builder
 RUN apk add --no-cache wget git
 
-ARG SOURCE_COMMIT
+ARG COMMIT
 ARG DOCKER_TAG
-ENV SOURCE_COMMIT $SOURCE_COMMIT
-ENV DOCKER_TAG $DOCKER_TAG
+ENV COMMIT ${COMMIT}
+ENV DOCKER_TAG ${DOCKER_TAG}
 
 WORKDIR /build
 COPY . .
 RUN go mod download && CGO_ENABLED=0 go build \
-  -ldflags "-s -w -X github.com/go-crzy/crzy/pkg.version=${DOCKER_TAG:-dev} -X github.com/go-crzy/crzy/pkg.commit=${SOURCE_COMMIT:-unknown}" \
+  -ldflags "-s -w -X github.com/go-crzy/crzy/pkg.version=${DOCKER_TAG:-dev} -X github.com/go-crzy/crzy/pkg.commit=${COMMIT:-unknown}" \
   -o crzy .
 
 FROM golang:1.16-alpine

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,1 @@
+../../hooks/build

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+COMMIT=$(echo $SOURCE_COMMIT | cut -c1-16)
+docker build . --build-arg DOCKER_TAG=${DOCKER_TAG} --build-arg COMMIT=${COMMIT} -t ${IMAGE_NAME}


### PR DESCRIPTION
This PR adds a build script in the `hooks` directory to replace the default docker hub automatic build. This allows to pass `--build-arg` tags to the build with the version/sha.